### PR TITLE
Bump rack version to pick up security patches

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.3)
       rack
     rack-ssl (1.4.1)
@@ -167,4 +167,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.3


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-16470
https://nvd.nist.gov/vuln/detail/CVE-2018-16471